### PR TITLE
Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,18 @@ namespace eGandalf.Epi.PagePreview
 
         private void ResolvedPreviewId(ContentReference previewVersion, SegmentContext segmentContext)
         {
+            // return if no routed content, or routed content doesn't match preview
+            if (ContentReference.IsNullOrEmpty(segmentContext.RoutedContentLink) ||
+                !previewVersion.CompareToIgnoreWorkID(segmentContext.RoutedContentLink)) return;
+
+            segmentContext.RoutedContentLink = previewVersion;
+            //segmentContext.ContextMode = ContextMode.Preview; //messes up images, a FullPreview enum option would be super!
+
+            // just a simple key with true to tell router to display later in the pipeline
             if (HttpContextAccessor?.Invoke() is HttpContextBase context)
             {
                 context.Items[PreviewKey] = true;
-
             }
-            //segmentContext.ContextMode = ContextMode.Preview; //messes up images, a FullPreview enum option would be super!
         }
     }
 

--- a/eGandalf.Epi.PagePreview/Properties/AssemblyInfo.cs
+++ b/eGandalf.Epi.PagePreview/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.1.0")]
-[assembly: AssemblyFileVersion("2.2.1.0")]
+[assembly: AssemblyVersion("2.2.2.0")]
+[assembly: AssemblyFileVersion("2.2.2.0")]

--- a/eGandalf.Epi.PagePreview/eGandalf.Epi.PagePreview.nuspec
+++ b/eGandalf.Epi.PagePreview/eGandalf.Epi.PagePreview.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>eGandalf.Epi.PagePreview</id>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <authors>James Stout (@egandalf)</authors>
     <owners>Episerver</owners>
     <projectUrl>https://github.com/egandalf/eGandalf.Epi.PagePreview</projectUrl>

--- a/eGandalf.Epi.PagePreview/eGandalf.Epi.PagePreview/ClientResources/PagePreview.js
+++ b/eGandalf.Epi.PagePreview/eGandalf.Epi.PagePreview/ClientResources/PagePreview.js
@@ -34,8 +34,10 @@
             }, 
             getPublicUrlWithTrailingSlash: function(context) {
                 var url = context["publicUrl"];
-                if (!url.endsWith("/")) {
-                    url = url + "/";
+                var suffix = "/";
+                if (url.indexOf(suffix, url.length - suffix.length) === -1)
+                {
+                    url = url + suffix;
                 }
 
                 return url;


### PR DESCRIPTION
IE doesn't support endsWith, which resulted in breaking the UI when page preview was used. I've changed it to use indexOf check.

Also updated the anonymous preview sample for unpublished content to set the segment context on the route, only if the segment matches the already routed content.

And finally bumped assemblyinfo and nuspec to version 2.2.2.